### PR TITLE
Update Dupicate Contact Conditions

### DIFF
--- a/api/AddContact.php
+++ b/api/AddContact.php
@@ -140,12 +140,11 @@ function contactExists(mysqli $conn, array $payload): bool{
     $query = $conn->prepare("
     SELECT COUNT(*) AS cnt
     FROM Contacts
-    WHERE FirstName = ? 
-      AND LastName  = ? 
-      AND Email     = ? 
-      AND Phone     = ? 
-      AND UserId    = ?
-    ");
+    WHERE FirstName = ?
+        AND LastName = ?
+        AND (Email = ? OR Phone = ?)
+        AND UserId = ?
+       ");
 
     $query->bind_param("ssssi",
         $payload["firstName"],

--- a/api/UpdateContact.php
+++ b/api/UpdateContact.php
@@ -106,14 +106,17 @@ try {
     }
 
     // duplicate check TODO do we want to allow duplicates or not??
-    $stmt = $db->prepare(
-        "SELECT COUNT(*) AS cnt
-         FROM Contacts
-         WHERE UserId = ?
-           AND ID <> ?
-           AND (Email = ? OR Phone = ?)"
-    );
-    $stmt->bind_param("iiss", $userId, $contactId, $email, $phone);
+    $stmt = $db->prepare("
+    SELECT COUNT(*) AS cnt
+    FROM Contacts
+    WHERE FirstName = ?
+        AND LastName = ?
+        AND (Email = ? OR Phone = ?)
+        AND ID <> ?
+        AND UserId = ?
+       ");
+
+    $stmt->bind_param("ssssii", $firstName, $lastName, $email, $phone, $contactId, $userId);
     $stmt->execute();
     $row = $stmt->get_result()->fetch_assoc();
     $stmt->close();


### PR DESCRIPTION
Change: Update conditions for checking if a contact is a dup or not in both AddContact and UpdateContact API's

Why?: To have a uniform definition for a duplicate contact across the program

Authored By: Jordan Sanchez